### PR TITLE
add PoliteBufferedConsumer and set it as default one

### DIFF
--- a/pyramid_mixpanel/__init__.py
+++ b/pyramid_mixpanel/__init__.py
@@ -9,6 +9,7 @@ MixpanelTrack is prepared as `request.mixpanel` for easier usage in view code.
 """
 from dataclasses import dataclass
 from pyramid.config import Configurator
+from pyramid.events import NewRequest
 
 
 @dataclass(frozen=True)
@@ -161,6 +162,8 @@ class ProfileMetaProperties:
 
 def includeme(config: Configurator) -> None:
     """Pyramid knob."""
-    from pyramid_mixpanel.track import mixpanel_track
+    from pyramid_mixpanel.track import mixpanel_init
+    from pyramid_mixpanel.track import mixpanel_flush
 
-    config.add_request_method(mixpanel_track, "mixpanel", reify=True)
+    config.add_request_method(mixpanel_init, "mixpanel", reify=True)
+    config.add_subscriber(mixpanel_flush, NewRequest)

--- a/pyramid_mixpanel/tests/test_consumers.py
+++ b/pyramid_mixpanel/tests/test_consumers.py
@@ -1,0 +1,57 @@
+"""Tests for provided consumers."""
+
+from pyramid_mixpanel.consumer import MockedConsumer
+from pyramid_mixpanel.consumer import MockedMessage
+from pyramid_mixpanel.consumer import PoliteBufferedConsumer
+from testfixtures import LogCapture
+from unittest import mock
+from urllib.error import URLError
+
+import structlog
+
+
+def test_MockedConsumer() -> None:
+    """Test that MockedConsumer saves messages."""
+    consumer = MockedConsumer()
+
+    consumer.send(endpoint="events", json_message='{"foo":"Foo"}')
+    consumer.send(endpoint="events", json_message='{"bar":"Bar"}')
+
+    assert len(consumer.mocked_messages) == 2
+    assert consumer.mocked_messages[0] == MockedMessage("events", {"foo": "Foo"})
+    assert consumer.mocked_messages[1] == MockedMessage("events", {"bar": "Bar"})
+
+
+@mock.patch("mixpanel.BufferedConsumer.flush")
+def test_PoliteBufferedConsumer(flush: mock.MagicMock) -> None:
+    """Test that PoliteBufferedConsumer logs errors and continues."""
+    structlog.configure(
+        processors=[structlog.processors.KeyValueRenderer(sort_keys=True)],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+    )
+
+    consumer = PoliteBufferedConsumer()
+
+    consumer.send(endpoint="events", json_message='{"foo":"Foo"}')
+    consumer.send(endpoint="events", json_message='{"bar":"Bar"}')
+
+    assert consumer._buffers == {  # noqa: SF01
+        "events": ['{"foo":"Foo"}', '{"bar":"Bar"}'],
+        "people": [],
+        "imports": [],
+    }
+
+    consumer.flush()
+    flush.assert_called_with()
+
+    with LogCapture() as logs:
+        flush.side_effect = URLError("foo")
+        consumer.flush()
+
+    logs.check(
+        (
+            "pyramid_mixpanel.consumer",
+            "ERROR",
+            "event='It seems like Mixpanel is down.' exc_info=True",
+        )
+    )

--- a/pyramid_mixpanel/tests/test_functional.py
+++ b/pyramid_mixpanel/tests/test_functional.py
@@ -1,6 +1,7 @@
 """Functional tests against a real Pyramid app."""
 
 from freezegun import freeze_time
+from mixpanel import json_dumps
 from pyramid.config import Configurator
 from pyramid.request import Request
 from pyramid.router import Router
@@ -8,10 +9,14 @@ from pyramid.view import view_config
 from pyramid_mixpanel import EventProperties
 from pyramid_mixpanel import Events
 from pyramid_mixpanel.tests.test_track import _make_user
+from testfixtures import LogCapture
 from unittest import mock
 from webtest import TestApp
 
+import base64
+import structlog
 import typing as t
+import urllib
 
 
 @view_config(route_name="hello", renderer="json", request_method="GET")
@@ -25,28 +30,63 @@ def hello(request: Request) -> t.Dict[str, str]:
 
 def app() -> Router:
     """Create a dummy Pyramid app."""
+    structlog.configure(
+        processors=[structlog.processors.KeyValueRenderer(sort_keys=True)],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+    )
+
     with Configurator() as config:
         config.add_route("hello", "/hello")
         config.scan(".")
 
-        config.registry.settings["mixpanel.testing"] = True
+        config.registry.settings["mixpanel.token"] = "SECRET"
         config.include("pyramid_mixpanel")
 
         return config.make_wsgi_app()
 
 
-@mock.patch("pyramid_mixpanel.track.MockedConsumer")
-@freeze_time("2018-01-01")
-def test_mixpanel_request_accessor(mocked_consumer) -> None:
+@freeze_time("2019-01-01")
+@mock.patch("mixpanel.urllib.request.urlopen")
+@mock.patch("mixpanel.urllib.request.Request")
+def test_request_mixpanel(request: mock.MagicMock, urlopen: mock.MagicMock) -> None:
     """Test that request.mixpanel works as expected."""
-    testapp = TestApp(app())
+    urlopen().read.return_value = b'{"error":null,"status":1}'
 
-    res = testapp.get("/hello", status=200)
-    assert res.json == {"hello": "world"}
+    with LogCapture() as logs:
 
-    mocked_consumer().send.assert_called_with(
-        "events",
-        '{"event":"Page Viewed","properties":{"token":"testing",'
-        '"distinct_id":"distinct id","time":1514764800,"mp_lib":"python",'
-        '"$lib_version":"4.4.0","Path":"/hello"}}',
+        testapp = TestApp(app())
+
+        res = testapp.get("/hello", status=200)
+        assert res.json == {"hello": "world"}
+
+    logs.check(
+        (
+            "pyramid_mixpanel.track",
+            "INFO",
+            "consumer='PoliteBufferedConsumer' event='request.mixpanel configured' "
+            "event_properties='EventProperties' events='Events' "
+            "profile_meta_properties='ProfileMetaProperties' "
+            "profile_properties='ProfileProperties'",
+        )
+    )
+
+    message = json_dumps(
+        [
+            {
+                "event": "Page Viewed",
+                "properties": {
+                    "token": "SECRET",
+                    "distinct_id": "distinct id",
+                    "time": 1546300800,
+                    "mp_lib": "python",
+                    "$lib_version": "4.4.0",
+                    "Path": "/hello",
+                },
+            }
+        ]
+    )
+    data = {"data": base64.b64encode(message.encode("utf8")), "verbose": 1, "ip": 0}
+    request.assert_called_with(
+        "https://api.mixpanel.com/track",
+        urllib.parse.urlencode(data).encode("utf8"),  # type:ignore
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,6 @@ ignore_missing_imports = True
 
 [mypy-webtest.*]
 ignore_missing_imports = True
+
+[mypy-testfixtures.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Also configure it so that `.flush()` is called at the end of request, so developers don't need to remember to call flush() at the end of their view code.