### PR TITLE
Make initial user as not mandatory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ config.include("pyramid_mixpanel")
 # for local development and unit testing
 mixpanel.testing = true
 
+# if `user` models doesn't exists
+mixpanel.no_initial_user = true
+
 # minimal configuration
 mixpanel.token = <TOKEN>
 
@@ -92,6 +95,18 @@ mixpanel.token = myapp.mixpanel.dinamic_token
 For view code dealing with requests, a pre-configured `request.mixpanel`
 is available.
 
+## User configuration
+
+A `user` object needs to have following attributes:
+  * distinct_id: str
+  * email: str
+  * name: str
+  * created: datetime.datetime
+  * state: str
+
+If `mixpanel.no_initial_user` is true then `request.mixpanel.user` needs to be initialized with User object along with at least `distinct_id` attribute.
+
+`request.mixpanel.profile_sync()` can be used to create/update profile.
 
 ## Design defense
 

--- a/pyramid_mixpanel/tests/test_track.py
+++ b/pyramid_mixpanel/tests/test_track.py
@@ -11,6 +11,7 @@ from pyramid_mixpanel import ProfileProperties
 from pyramid_mixpanel import Property
 from pyramid_mixpanel.consumer import MockedConsumer
 from pyramid_mixpanel.consumer import PoliteBufferedConsumer
+from pyramid_mixpanel.track import mixpanel_init
 from pyramid_mixpanel.track import MixpanelTrack
 from unittest import mock
 
@@ -436,3 +437,14 @@ def test_profile_track_charge() -> None:
         "$distinct_id": "distinct id",
         "$append": {"$transactions": {"Foo": "Bar", "$amount": 222}},
     }
+
+
+def test_init_method_without_user() -> None:
+    """Test track init method without user."""
+    request = mock.Mock()
+    request.registry.settings = {
+        "mixpanel.token": "testing",
+        "mixpanel.no_initial_user": True,
+    }
+    mi = mixpanel_init(request)
+    assert mi.user is None

--- a/pyramid_mixpanel/track.py
+++ b/pyramid_mixpanel/track.py
@@ -214,7 +214,14 @@ class MixpanelTrack:
 
 def mixpanel_init(request: Request) -> MixpanelTrack:
     """Return a configured MixpanelTrack class instance."""
-    mixpanel = MixpanelTrack(settings=request.registry.settings, user=request.user)
+
+    settings = request.registry.settings
+    if settings.get("mixpanel.no_initial_user"):
+        user = None
+    else:
+        user = request.user
+
+    mixpanel = MixpanelTrack(settings=settings, user=user)
     logger.info(
         "request.mixpanel configured",
         consumer=mixpanel.api._consumer.__class__.__name__,


### PR DESCRIPTION
This PR fixes the issue having a default user model as None if the sites don't possess a `user` model.