### PR TITLE
Don't flood logs with "mixpanel configured" messages

### DIFF
--- a/pyramid_mixpanel/tests/test_functional.py
+++ b/pyramid_mixpanel/tests/test_functional.py
@@ -56,22 +56,25 @@ def test_MockedConsumer() -> None:
     with LogCapture() as logs:
         testapp = TestApp(app({}))
 
+        # do two requests to make sure logs are not flooded with messages
+        # on every request
+        res = testapp.get("/hello", status=200)
         res = testapp.get("/hello", status=200)
         assert res.json == {"hello": "world"}
 
     logs.check(
         (
-            "pyramid_mixpanel.track",
+            "pyramid_mixpanel",
             "INFO",
-            "consumer='MockedConsumer' event='request.mixpanel configured' "
+            "consumer='MockedConsumer' event='Mixpanel configured' "
             "event_properties='EventProperties' events='Events' "
             "profile_meta_properties='ProfileMetaProperties' "
             "profile_properties='ProfileProperties'",
         ),
         (
-            "pyramid_mixpanel.track",
+            "pyramid_mixpanel",
             "WARNING",
-            "event='mixpanel is in testing mode, no message will be sent'",
+            "event='Mixpanel is in testing mode, no message will be sent!'",
         ),
     )
 
@@ -111,9 +114,9 @@ def test_PoliteBufferedConsumer(
 
     logs.check(
         (
-            "pyramid_mixpanel.track",
+            "pyramid_mixpanel",
             "INFO",
-            "consumer='PoliteBufferedConsumer' event='request.mixpanel configured' "
+            "consumer='PoliteBufferedConsumer' event='Mixpanel configured' "
             "event_properties='EventProperties' events='Events' "
             "profile_meta_properties='ProfileMetaProperties' "
             "profile_properties='ProfileProperties'",

--- a/pyramid_mixpanel/track.py
+++ b/pyramid_mixpanel/track.py
@@ -14,10 +14,7 @@ from pyramid_mixpanel import Property
 from pyramid_mixpanel.consumer import MockedConsumer
 from pyramid_mixpanel.consumer import PoliteBufferedConsumer
 
-import structlog
 import typing as t
-
-logger = structlog.get_logger(__name__)
 
 SettingsType = t.Dict[str, t.Union[str, int, bool]]
 PropertiesType = t.Dict[Property, t.Union[str, int, bool]]
@@ -206,18 +203,7 @@ class MixpanelTrack:
 
 def mixpanel_init(request: Request) -> MixpanelTrack:
     """Return a configured MixpanelTrack class instance."""
-    mixpanel = MixpanelTrack(settings=request.registry.settings, user=request.user)
-    logger.info(
-        "request.mixpanel configured",
-        consumer=mixpanel.api._consumer.__class__.__name__,
-        events=mixpanel.events.__class__.__name__,
-        event_properties=mixpanel.event_properties.__class__.__name__,
-        profile_properties=mixpanel.profile_properties.__class__.__name__,
-        profile_meta_properties=mixpanel.profile_meta_properties.__class__.__name__,
-    )
-    if mixpanel.api._consumer.__class__ == MockedConsumer:
-        logger.warning("mixpanel is in testing mode, no message will be sent")
-    return mixpanel
+    return MixpanelTrack(settings=request.registry.settings, user=request.user)
 
 
 def mixpanel_flush(event: NewRequest) -> None:


### PR DESCRIPTION
Instead of printing "mixpanel configured" messages on every request,
do it only once at app startup.