### PR TITLE
Initial support for Customer.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ types: .installed
 
 .PHONY: sort
 sort: .installed
-	@pipenv run isort -rc --atomic pyramid_mixpanel
-	@pipenv run isort -rc --atomic setup.py
+	@pipenv run isort --atomic pyramid_mixpanel
+	@pipenv run isort --atomic setup.py
 
 .PHONY: fmt
 fmt: format

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 python_version = "3.8"
 
 [packages]
-pyramid-mixpanel = {editable = true,path = "."}
+pyramid-mixpanel = {editable = true,path = ".",extras = ["customerio"]}
 
 [dev-packages]
 black = "==21.8b0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e209d07369ca812b64ace20d8377cf16981d2ade3fe6392b9cf396212498c4fb"
+            "sha256": "933f7e0bf57899401810f725e394b97632906523b25f2021efd6fc9c8e801310"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,11 +25,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367",
-                "sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd"
+                "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6",
+                "sha256:5ec46d183433dcbd0ab716f2d7f29d8dee50505b3fdb40c6b985c7c4f5a3591f"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.5"
+            "version": "==2.0.6"
         },
         "customerio": {
             "hashes": [
@@ -94,6 +94,9 @@
         },
         "pyramid-mixpanel": {
             "editable": true,
+            "extras": [
+                "customerio"
+            ],
             "path": "."
         },
         "requests": {
@@ -121,11 +124,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
-                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.6"
+            "version": "==1.26.7"
         },
         "venusian": {
             "hashes": [
@@ -266,11 +269,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367",
-                "sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd"
+                "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6",
+                "sha256:5ec46d183433dcbd0ab716f2d7f29d8dee50505b3fdb40c6b985c7c4f5a3591f"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.5"
+            "version": "==2.0.6"
         },
         "click": {
             "hashes": [
@@ -351,15 +354,15 @@
                 "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
                 "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==5.5"
         },
         "distlib": {
             "hashes": [
-                "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736",
-                "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"
+                "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31",
+                "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"
             ],
-            "version": "==0.3.2"
+            "version": "==0.3.3"
         },
         "docutils": {
             "hashes": [
@@ -519,11 +522,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:113a76a6ba614d2a3dd408b3504446bcfac0370da5995aa6a17fd7c6dffde02d",
-                "sha256:32f465f3c48083f345ad29a9df8419a4ce0674bf4a8c3245191d65c83634bdbf"
+                "sha256:528a88021749035d5a39fe2ba67c0642b8341aaf71889da0e1ed669a429b87f0",
+                "sha256:de83a84d774921669774a2000bf87ebba46b4d1c04775f4a5d37deff0cf39f73"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==2.2.14"
+            "version": "==2.2.15"
         },
         "idna": {
             "hashes": [
@@ -553,7 +556,7 @@
                 "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899",
                 "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==5.9.3"
         },
         "keyring": {
@@ -996,10 +999,10 @@
         },
         "testfixtures": {
             "hashes": [
-                "sha256:0a6422737f6d89b45cdef1e2df5576f52ad0f507956002ce1020daa9f44211d6",
-                "sha256:486be7b01eb71326029811878a3317b7e7994324621c0ec633c8e24499d8d5b3"
+                "sha256:61c25cb0213f68d2dcd2b098d9d2e7f47afc3b4429d66e1cdeb1072be2fcb241",
+                "sha256:9c2316232de0ef6915d5446dcccaec9c4a6092751ba2ff7d30b9c14a954a90e3"
             ],
-            "version": "==6.18.1"
+            "version": "==6.18.2"
         },
         "toml": {
             "hashes": [
@@ -1019,11 +1022,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:80aead664e6c1672c4ae20dc50e1cdc5e20eeff9b14aa23ecd426375b28be588",
-                "sha256:a4d6d112e507ef98513ac119ead1159d286deab17dffedd96921412c2d236ff5"
+                "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c",
+                "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.62.2"
+            "version": "==4.62.3"
         },
         "twine": {
             "hashes": [
@@ -1043,11 +1046,11 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:a5a305b43ea57bf64d6731f89816946a405b591eff6de28d4c0fd58422cee779",
-                "sha256:e21541c0f55c066c491a639309159556dd8c5833e49fcde929c4c47bdb0002ee"
+                "sha256:225ac2e86549b6ef3a8a44bf955f80b4955855704a15d2883d8445c8df637242",
+                "sha256:26e90866bcd773d76b316de7e6bd6e24641f9e1653cf27241c533886600f6824"
             ],
             "index": "pypi",
-            "version": "==2.25.6"
+            "version": "==2.25.8"
         },
         "typing-extensions": {
             "hashes": [
@@ -1059,19 +1062,19 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
-                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.6"
+            "version": "==1.26.7"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:9ef4e8ee4710826e98ff3075c9a4739e2cb1040de6a2a8d35db0055840dc96a0",
-                "sha256:e4670891b3a03eb071748c569a87cceaefbf643c5bac46d996c5a45c34aa0f06"
+                "sha256:10062e34c204b5e4ec5f62e6ef2473f8ba76513a9a617e873f1f8fb4a519d300",
+                "sha256:bcc17f0b3a29670dd777d6f0755a4c04f28815395bca279cdcb213b97199a6b8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.7.2"
+            "version": "==20.8.1"
         },
         "waitress": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,11 +25,17 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
-                "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
+                "sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367",
+                "sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.4"
+            "version": "==2.0.5"
+        },
+        "customerio": {
+            "hashes": [
+                "sha256:1f119f8fc29ae80675da14876822a7198262d0ef7d836eb3bf7c35f336b6c0e6"
+            ],
+            "version": "==1.2"
         },
         "hupper": {
             "hashes": [
@@ -260,11 +266,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
-                "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
+                "sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367",
+                "sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.4"
+            "version": "==2.0.5"
         },
         "click": {
             "hashes": [
@@ -395,11 +401,11 @@
         },
         "flake8-bugbear": {
             "hashes": [
-                "sha256:2346c81f889955b39e4a368eb7d508de723d9de05716c287dc860a4073dc57e7",
-                "sha256:4f305dca96be62bf732a218fe6f1825472a621d3452c5b994d8f89dae21dbafa"
+                "sha256:2f60c8ce0dc53d51da119faab2d67dea978227f0f92ed3c44eb7d65fb2e06a96",
+                "sha256:45bfdccfb9f2d8aa140e33cac8f46f1e38215c13d5aa8650e7e188d84e2f94c6"
             ],
             "index": "pypi",
-            "version": "==21.4.3"
+            "version": "==21.9.1"
         },
         "flake8-builtins": {
             "hashes": [
@@ -552,11 +558,11 @@
         },
         "keyring": {
             "hashes": [
-                "sha256:1e1970dcecde00c59ff6033d69cee3b283cd0d7cbad78b0dc4cdd15c8a28bcf8",
-                "sha256:66a08700421ed0aaf317c6bf6543f7345f9ab9e7bed6e0ee072f7f6fcddbab75"
+                "sha256:6334aee6073db2fb1f30892697b1730105b5e9a77ce7e61fca6b435225493efe",
+                "sha256:bd2145a237ed70c8ce72978b497619ddfcae640b6dcf494402d5143e37755c6e"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==23.2.0"
+            "version": "==23.2.1"
         },
         "lxml": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The reason this package exists is to provide sane defaults when integrating with
 - You **defer sending events until the entire request is processed successfully**, i.e. never send events like "User added a thing" if adding the thing to DB failed at a later stage in the request life-cycle.
 
 NOTE: At the end of 2021, Mixpanel is [sunsetting their Email Messages](https://mixpanel.com/blog/why-were-sunsetting-messaging-and-experiments/) feature. Since we rely heavily on those at
-[Niteo](https://niteo.co), we are adding [Customer.io integration]() into this library, to replace Mixpanel's Email Messages. If you don't want to use Customer.io, nothing changes for you, just keep using `pyramid_mixpanel` as always. If you do want to use Customer.io, then
-add the following registry settings, and all `profile_set` and `track` calls will get automatically replicated to Customer.io. Other calls such as `profile_append` will only send to Mixpanel.
+[Niteo](https://niteo.co), we are adding [Customer.io](https://customer.io/) integration into this library, to replace Mixpanel's Email Messages. If you don't want to use Customer.io, nothing changes for you, just keep using `pyramid_mixpanel` as always. If you do want to use Customer.io, then
+install this package as `pyramid_mixpanel[customerio]` and add the following registry settings. Then all `profile_set` and `track` calls will get automatically replicated to Customer.io. Other calls such as `profile_append` will only send to Mixpanel.
 
 ```ini
 customerio.tracking.site_id: <secret>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
   </a>
 </p>
 
-## Opinionated Mixpanel integration
+## Opinionated Mixpanel (and Customer.io) integration
 
 The reason this package exists is to provide sane defaults when integrating with Mixpanel. Instead of chasing down event name typos and debugging why tracking does not work, you can focus on learning what is important to your users.
 
@@ -45,6 +45,16 @@ The reason this package exists is to provide sane defaults when integrating with
 - Your **app never stops working if Mixpanel is down**, but you still get errors in your logs so you know what is going on.
 - You **never forget to call `flush()`** on the events buffer, since `pyramid_mixpanel` hooks into the request life-cycle and calls `flush()` at the end of the request processing.
 - You **defer sending events until the entire request is processed successfully**, i.e. never send events like "User added a thing" if adding the thing to DB failed at a later stage in the request life-cycle.
+
+NOTE: At the end of 2021, Mixpanel is [sunsetting their Email Messages](https://mixpanel.com/blog/why-were-sunsetting-messaging-and-experiments/) feature. Since we rely heavily on those at
+[Niteo](https://niteo.co), we are adding [Customer.io integration]() into this library, to replace Mixpanel's Email Messages. If you don't want to use Customer.io, nothing changes for you, just keep using `pyramid_mixpanel` as always. If you do want to use Customer.io, then
+add the following registry settings, and all `profile_set` and `track` calls will get automatically replicated to Customer.io. Other calls such as `profile_append` will only send to Mixpanel.
+
+```ini
+customerio.tracking.site_id: <secret>
+customerio.tracking.api_key: <secret>
+customerio.tracking.region: <eu OR us>
+```
 
 
 ## Features

--- a/pyramid_mixpanel/__init__.py
+++ b/pyramid_mixpanel/__init__.py
@@ -175,6 +175,7 @@ def includeme(config: Configurator) -> None:
             event_properties=mixpanel.event_properties.__class__.__name__,
             profile_properties=mixpanel.profile_properties.__class__.__name__,
             profile_meta_properties=mixpanel.profile_meta_properties.__class__.__name__,
+            customerio=True if mixpanel.cio else False,
         )
         if mixpanel.api._consumer.__class__ == MockedConsumer:
             logger.warning("Mixpanel is in testing mode, no message will be sent!")
@@ -190,7 +191,8 @@ def includeme(config: Configurator) -> None:
             f"events={mixpanel.events.__class__.__name__}, "
             f"event_properties={mixpanel.event_properties.__class__.__name__}, "
             f"profile_properties={mixpanel.profile_properties.__class__.__name__}, "
-            f"profile_meta_properties={mixpanel.profile_meta_properties.__class__.__name__}"
+            f"profile_meta_properties={mixpanel.profile_meta_properties.__class__.__name__}, "
+            f"customerio={True if mixpanel.cio else False}"
         )
         if mixpanel.api._consumer.__class__ == MockedConsumer:
             logger.warning("Mixpanel is in testing mode, no message will be sent!")

--- a/pyramid_mixpanel/tests/test_functional.py
+++ b/pyramid_mixpanel/tests/test_functional.py
@@ -156,9 +156,9 @@ def test_PoliteBufferedConsumer(_make_insert_id) -> None:
         settings = {
             "mixpanel.token": "SECRET",
             "pyramid_heroku.structlog": True,
-            "customerio.site_id": "secret",
-            "customerio.api_key": "secret",
-            "customerio.region": "eu",
+            "customerio.tracking.site_id": "secret",
+            "customerio.tracking.api_key": "secret",
+            "customerio.tracking.region": "eu",
         }
         testapp = TestApp(app(settings))
 

--- a/pyramid_mixpanel/tests/test_track.py
+++ b/pyramid_mixpanel/tests/test_track.py
@@ -198,9 +198,9 @@ def test_mixpanel_init_customerio() -> None:
 
     # However if correct settings are provided, Customer.io API object is created
     request.registry.settings = {
-        "customerio.site_id": "secret",
-        "customerio.api_key": "secret",
-        "customerio.region": "eu",
+        "customerio.tracking.site_id": "secret",
+        "customerio.tracking.api_key": "secret",
+        "customerio.tracking.region": "eu",
     }
 
     result = mixpanel_init(request)
@@ -209,13 +209,13 @@ def test_mixpanel_init_customerio() -> None:
     assert "eu" in result.cio.base_url
 
     # US region is also possible
-    request.registry.settings["customerio.region"] = "us"
+    request.registry.settings["customerio.tracking.region"] = "us"
 
     result = mixpanel_init(request)
     assert "us" in result.cio.base_url
 
     # fail on bad region
-    request.registry.settings["customerio.region"] = "foo"
+    request.registry.settings["customerio.tracking.region"] = "foo"
 
     with pytest.raises(ValueError) as cm:
         result = mixpanel_init(request)
@@ -465,9 +465,9 @@ def test_track_customerio() -> None:
 
     m = MixpanelTrack(
         settings={
-            "customerio.site_id": "foo",
-            "customerio.api_key": "secret",
-            "customerio.region": "eu",
+            "customerio.tracking.site_id": "foo",
+            "customerio.tracking.api_key": "secret",
+            "customerio.tracking.region": "eu",
         },
         distinct_id="foo",
     )
@@ -573,9 +573,9 @@ def test_profile_set_customerio() -> None:
     """Test setting a profile property on Customer.io."""
     m = MixpanelTrack(
         settings={
-            "customerio.site_id": "foo",
-            "customerio.api_key": "secret",
-            "customerio.region": "eu",
+            "customerio.tracking.site_id": "foo",
+            "customerio.tracking.api_key": "secret",
+            "customerio.tracking.region": "eu",
         },
         distinct_id="foo",
     )

--- a/pyramid_mixpanel/track.py
+++ b/pyramid_mixpanel/track.py
@@ -181,20 +181,20 @@ class MixpanelTrack:
             self.global_event_props = {}
 
         if (
-            settings.get("customerio.site_id")
-            and settings.get("customerio.api_key")
-            and settings.get("customerio.region")
+            settings.get("customerio.tracking.site_id")
+            and settings.get("customerio.tracking.api_key")
+            and settings.get("customerio.tracking.region")
         ):
-            if settings["customerio.region"] == "eu":
+            if settings["customerio.tracking.region"] == "eu":
                 region = Regions.EU
-            elif settings["customerio.region"] == "us":
+            elif settings["customerio.tracking.region"] == "us":
                 region = Regions.US
             else:
                 raise ValueError("Unknown customer.io region")
 
             self.cio = CustomerIO(
-                settings["customerio.site_id"],
-                settings["customerio.api_key"],
+                settings["customerio.tracking.site_id"],
+                settings["customerio.tracking.api_key"],
                 region=region,
             )
         else:

--- a/pyramid_mixpanel/track.py
+++ b/pyramid_mixpanel/track.py
@@ -1,7 +1,5 @@
 """Tracking user events and profiles."""
 
-from customerio import CustomerIO
-from customerio import Regions
 from mixpanel import BufferedConsumer
 from mixpanel import Consumer
 from mixpanel import Mixpanel
@@ -185,6 +183,11 @@ class MixpanelTrack:
             and settings.get("customerio.tracking.api_key")
             and settings.get("customerio.tracking.region")
         ):
+            # This is here because customerio support is an install extra,
+            # i.e. it is optional
+            from customerio import CustomerIO
+            from customerio import Regions
+
             if settings["customerio.tracking.region"] == "eu":
                 region = Regions.EU
             elif settings["customerio.tracking.region"] == "us":

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ check_untyped_defs = True
 html_report = ./htmltypecov
 linecount_report = ./typecov
 
+[mypy-customerio.*]
+ignore_missing_imports = True
+
 [mypy-freezegun.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,8 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=["pyramid", "requests", "mixpanel", "customerio"],
+    extra_requires={
+        "customerio": ["customerio"],
+    },
     cmdclass={"verify": VerifyVersionCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     keywords="pyramid mixpanel pylons web",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["pyramid", "requests", "mixpanel"],
+    install_requires=["pyramid", "requests", "mixpanel", "customerio"],
     cmdclass={"verify": VerifyVersionCommand},
 )


### PR DESCRIPTION
Remaining issues:
* tracking probably breaks if `track` is called before `profile_set`
* `profile_` calls other than `profile_set` are silently ignored for Customer.io
  because they are not supported on Customer.io.
* PoliteBufferedConsumer is not buffering Customer.io requests, but sends them
  immediately

Refs https://github.com/niteoweb/pareto/issues/63