### PR TITLE
Support for skipping arbitrary track/profile_set calls to Customer.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ customerio.tracking.api_key: <secret>
 customerio.tracking.region: <eu OR us>
 ```
 
+If you want to skip sending some `track` or `profile_set` calls to Customer.io, add the `skip_customerio=True` as a function parameter.
+
 
 ## Features
 

--- a/pyramid_mixpanel/tests/test_track.py
+++ b/pyramid_mixpanel/tests/test_track.py
@@ -507,7 +507,13 @@ def test_track_customerio() -> None:
         "name": "Page Viewed",
         "referrer": "https://niteo.co",  # dollar sign was removed
     }
+
+    # Test that we can skip sending data to Customer.io
     m.api._consumer.mocked_messages.clear()
+    m.track(Events.page_viewed, {}, skip_customerio=True)
+    assert len(m.api._consumer.mocked_messages) == 1
+    assert m.api._consumer.mocked_messages[0].endpoint == "events"
+    assert m.api._consumer.mocked_messages[0].msg["event"] == "Page Viewed"
 
 
 def test_track_guards() -> None:
@@ -601,6 +607,13 @@ def test_profile_set_customerio() -> None:
         "name": "FooBar",
         "ip": "1.1.1.1",  # dollar sign was removed
     }
+
+    # Test that we can skip sending data to Customer.io
+    m.api._consumer.mocked_messages.clear()
+    m.profile_set({ProfileProperties.dollar_name: "NoCustomerIO"}, skip_customerio=True)
+    assert len(m.api._consumer.mocked_messages) == 1
+    assert m.api._consumer.mocked_messages[0].endpoint == "people"
+    assert m.api._consumer.mocked_messages[0].msg["$set"] == {"$name": "NoCustomerIO"}
 
 
 def test_profile_set_guards() -> None:

--- a/pyramid_mixpanel/track.py
+++ b/pyramid_mixpanel/track.py
@@ -206,7 +206,12 @@ class MixpanelTrack:
             self.cio = None
 
     @distinct_id_is_required
-    def track(self, event: Event, props: t.Optional[PropertiesType] = None) -> None:
+    def track(
+        self,
+        event: Event,
+        props: t.Optional[PropertiesType] = None,
+        skip_customerio: bool = False,
+    ) -> None:
         """Track a Mixpanel event."""
         if event not in self.events.__dict__.values():
             raise ValueError(f"Event '{event}' is not a member of self.events")
@@ -226,7 +231,7 @@ class MixpanelTrack:
             event.name,
             {prop.name: value for (prop, value) in props.items()},
         )
-        if self.cio:
+        if self.cio and not skip_customerio:
             msg = {
                 "customer_id": self.distinct_id,
                 "name": event.name,
@@ -244,7 +249,10 @@ class MixpanelTrack:
 
     @distinct_id_is_required
     def profile_set(
-        self, props: PropertiesType, meta: t.Optional[PropertiesType] = None
+        self,
+        props: PropertiesType,
+        meta: t.Optional[PropertiesType] = None,
+        skip_customerio: bool = False,
     ) -> None:
         """Set properties to a Profile.
 
@@ -281,7 +289,7 @@ class MixpanelTrack:
             {prop.name: value for (prop, value) in props.items()},
             {prop.name: value for (prop, value) in meta.items()},
         )
-        if self.cio:
+        if self.cio and not skip_customerio:
 
             # customer.io expects dates in unix/epoch format
             for prop, value in customerio_props.items():


### PR DESCRIPTION
Refs https://github.com/teamniteo/pareto/issues/262