### PR TITLE
Configure pytest for better BlueRacer report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"
+
+[tool.pytest.ini_options]
+junit_duration_report = "call"


### PR DESCRIPTION
For test times, track only call durations.

Ref: https://blueracer.io/docs/runner/pytest#better-results